### PR TITLE
ci: add PyPI deploy stage with manual approval

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to PyPI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download wheels from latest GitHub Release
+        run: |
+          mkdir -p dist
+          gh release download --pattern '*.whl' --dir dist
+          echo "Downloaded wheels:"
+          ls -la dist/
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ./dist/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,9 @@ name: Deploy to PyPI
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "feat/pypi-deploy"
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,6 @@ name: Deploy to PyPI
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - "feat/pypi-deploy"
 
 jobs:
   deploy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,17 +188,20 @@ jobs:
   deploy_pypi:
     name: Deploy to PyPI
     runs-on: ubuntu-latest
-    needs: release
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'workflow_dispatch'
     environment: pypi
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: wheels_*
-          merge-multiple: true
-          path: ./dist/
+      - uses: actions/checkout@v4
+      - name: Download wheels from latest GitHub Release
+        run: |
+          mkdir -p dist
+          gh release download --pattern '*.whl' --dir dist
+          echo "Downloaded wheels:"
+          ls -la dist/
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,3 +184,22 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./dist/*.whl
+
+  deploy_pypi:
+    name: Deploy to PyPI
+    runs-on: ubuntu-latest
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/')
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels_*
+          merge-multiple: true
+          path: ./dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ./dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "v*"
-    branches:
-      - "feat/pypi-deploy"
   workflow_dispatch:
 
 jobs:
@@ -186,41 +184,3 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./dist/*.whl
-
-  deploy_pypi:
-    name: Deploy to PyPI
-    runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
-    environment: pypi
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download wheels from latest GitHub Release
-        run: |
-          mkdir -p dist
-          gh release download --pattern '*.whl' --dir dist
-          echo "Downloaded wheels:"
-          ls -la dist/
-        env:
-          GH_TOKEN: ${{ github.token }}
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: ./dist/
-
-  test_deploy:
-    name: Test Deploy (dry-run)
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download wheels from latest GitHub Release
-        run: |
-          mkdir -p dist
-          gh release download --pattern '*.whl' --dir dist
-          echo "Downloaded wheels:"
-          ls -la dist/
-          echo "Dry-run: would publish these to PyPI"
-        env:
-          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*"
+    branches:
+      - "feat/pypi-deploy"
   workflow_dispatch:
 
 jobs:
@@ -206,3 +208,19 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: ./dist/
+
+  test_deploy:
+    name: Test Deploy (dry-run)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download wheels from latest GitHub Release
+        run: |
+          mkdir -p dist
+          gh release download --pattern '*.whl' --dir dist
+          echo "Downloaded wheels:"
+          ls -la dist/
+          echo "Dry-run: would publish these to PyPI"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Add deploy_pypi job after release:
- Uses pypa/gh-action-pypi-publish with trusted publisher (OIDC)
- Requires manual approval via GitHub Environment 'pypi'
- Only triggers on tag pushes